### PR TITLE
Updated POM to turn off doclint for java 8 javadoc generation

### DIFF
--- a/ascent-platform-parent/pom.xml
+++ b/ascent-platform-parent/pom.xml
@@ -180,6 +180,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 				<version>3.0.0-M1</version>
 				<configuration>
 					<failOnError>false</failOnError>
+					<additionalparam>-Xdoclint:none</additionalparam>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
In Java 8, doclint runs against the java files for generating javadocs. In our generated sources by JAXB, they are not doclint compliant and it generates an error. I've disabled doclint for the maven-javadoc-plugin. More information can be found here on this:

http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html
