### PR TITLE
Gelf

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,11 @@ dockerPipeline {
 }
 
 dockerPipeline {
+    directory = 'ascent-platform-docker-build/fluentd'
+    imageName = 'ascent/fluentd'
+}
+
+dockerPipeline {
     directory = 'ascent-platform-docker-build/elasticsearch'
     imageName = 'ascent/ascent-elasticsearch'
 }

--- a/ascent-platform-docker-build/docker-compose.logging.override.yml
+++ b/ascent-platform-docker-build/docker-compose.logging.override.yml
@@ -18,6 +18,12 @@ services:
         environment: 
             - VAULT_TOKEN=
             - VAULT_ADDR=
+        logging:
+            driver: fluentd
+            options:
+                fluentd-async-connect: "true"
+                fluentd-max-retries: "10"
+                fluentd-retry-wait: "30s"    
 
     fluentd:
         build:

--- a/ascent-platform-docker-build/docker-compose.logging.override.yml
+++ b/ascent-platform-docker-build/docker-compose.logging.override.yml
@@ -2,23 +2,6 @@
 version: '3'
 
 services:
-    filebeat:
-        build:
-            context: ./filebeat
-        # Enable to turn on filebeat debugging
-        #command: ["filebeat", "-e", "-d", "publish"]
-        environment: 
-           - VAULT_TOKEN=
-           - VAULT_ADDR=
-        volumes:
-            - "/var/lib/docker/containers:/dockerlogs:ro"
-    logstash:
-        build:
-            context: ./logstash
-        environment: 
-           - VAULT_TOKEN=
-           - VAULT_ADDR=
-    
     elasticsearch:
         build:
             context: ./elasticsearch
@@ -35,17 +18,10 @@ services:
         environment: 
             - VAULT_TOKEN=
             - VAULT_ADDR=
-    
-    # vault:
-    #     image: vault
-    #     networks: 
-    #         - logging
-    #     ports: 
-    #         - 8200:8200
-    #     environment:
-    #         - VAULT_DEV_ROOT_TOKEN_ID=vaultroot
-    #     cap_add:
-    #         - IPC_LOCK
+
+    fluentd:
+        build:
+            context: ./fluentd
 
 networks:
   ascentnet:

--- a/ascent-platform-docker-build/docker-compose.logging.yml
+++ b/ascent-platform-docker-build/docker-compose.logging.yml
@@ -53,6 +53,9 @@ services:
             driver: fluentd
             options:
                 labels: "gov.va.ascent.component"
+                fluentd-async-connect: true
+                fluentd-max-retries: 10
+                fluentd-retry-wait: 30
         deploy:
             placement:
                 constraints: [node.role == worker]

--- a/ascent-platform-docker-build/docker-compose.logging.yml
+++ b/ascent-platform-docker-build/docker-compose.logging.yml
@@ -53,7 +53,7 @@ services:
             driver: fluentd
             options:
                 labels: "gov.va.ascent.component"
-                fluentd-async-connect: true
+                fluentd-async-connect: "true"
                 fluentd-max-retries: 10
                 fluentd-retry-wait: 30
         deploy:

--- a/ascent-platform-docker-build/docker-compose.logging.yml
+++ b/ascent-platform-docker-build/docker-compose.logging.yml
@@ -54,8 +54,8 @@ services:
             options:
                 labels: "gov.va.ascent.component"
                 fluentd-async-connect: "true"
-                fluentd-max-retries: 10
-                fluentd-retry-wait: 30
+                fluentd-max-retries: "10"
+                fluentd-retry-wait: "30s"
         deploy:
             placement:
                 constraints: [node.role == worker]

--- a/ascent-platform-docker-build/docker-compose.logging.yml
+++ b/ascent-platform-docker-build/docker-compose.logging.yml
@@ -49,13 +49,6 @@ services:
             - elasticsearch
         labels:
             gov.va.ascent.component: "logging"
-        logging:
-            driver: fluentd
-            options:
-                labels: "gov.va.ascent.component"
-                fluentd-async-connect: "true"
-                fluentd-max-retries: "10"
-                fluentd-retry-wait: "30s"
         deploy:
             placement:
                 constraints: [node.role == worker]

--- a/ascent-platform-docker-build/docker-compose.logging.yml
+++ b/ascent-platform-docker-build/docker-compose.logging.yml
@@ -25,26 +25,16 @@ services:
                 reservations:
                     memory: 1536m
 
-    filebeat:
-        image: docker.io/ascent/ascent-filebeat
-        volumes:
-            - "/var/lib/docker-latest/containers:/dockerlogs:ro"
-        networks: 
+    fluentd:
+        image: ascent/fluentd
+        ports:
+            - 24224:24224
+        networks:
             - logging
-            - ascentnet
-        depends_on:
-            - logstash
-        deploy:
-            mode: global
-    
-    logstash:
-        image: docker.io/ascent/ascent-logstash
-        networks: 
-            - logging
-            - ascentnet
         depends_on:
             - elasticsearch
         deploy:
+            mode: global
             placement:
                 constraints: [node.role == worker]
 
@@ -60,7 +50,7 @@ services:
         labels:
             gov.va.ascent.component: "logging"
         logging:
-            driver: json-file
+            driver: fluentd
             options:
                 labels: "gov.va.ascent.component"
         deploy:

--- a/ascent-platform-docker-build/docker-compose.yml
+++ b/ascent-platform-docker-build/docker-compose.yml
@@ -5,6 +5,12 @@ services:
     hostname: ascent-amqp
     networks:
         - ascentnet
+    logging:
+      driver: fluentd
+      options:
+        fluentd-async-connect: "true"
+        fluentd-max-retries: "10"
+        fluentd-retry-wait: "30s"
   ascent-discovery:
     image: ascent/ascent-discovery
     hostname: ascent-discovery
@@ -14,11 +20,12 @@ services:
       - SPRING_PROFILES_ACTIVE=aws-prod
       - VAULT_ADDR=${VAULT_ADDR}
       - VAULT_TOKEN=${VAULT_TOKEN}
-    # healthcheck:
-    #     test: ["CMD", "curl", "-f", "http://$DISCOVERY_USERNAME:$DISCOVERY_PASSWORD@localhost:8761"]
-    #     interval: 30s
-    #     timeout: 10s
-    #     retries: 5
+    logging:
+      driver: fluentd
+      options:
+        fluentd-async-connect: "true"
+        fluentd-max-retries: "10"
+        fluentd-retry-wait: "30s"
     networks:
         - ascentnet
   ascent-config: 
@@ -31,11 +38,12 @@ services:
       - VAULT_TOKEN=${VAULT_TOKEN}
       - VAULT_HOST=${VAULT_HOST}
       - VAULT_SCHEME=https
-    # healthcheck:
-    #     test: ["CMD", "curl", "-f", "http://localhost:8760/info"]
-    #     interval: 30s
-    #     timeout: 10s
-    #     retries: 5
+    logging:
+      driver: fluentd
+      options:
+        fluentd-async-connect: "true"
+        fluentd-max-retries: "10"
+        fluentd-retry-wait: "30s"
     depends_on:
       - ascent-discovery
     networks:
@@ -48,6 +56,12 @@ services:
       - SPRING_PROFILES_ACTIVE=aws-prod
       - VAULT_ADDR=${VAULT_ADDR}
       - VAULT_TOKEN=${VAULT_TOKEN}
+    logging:
+      driver: fluentd
+      options:
+        fluentd-async-connect: "true"
+        fluentd-max-retries: "10"
+        fluentd-retry-wait: "30s"
     depends_on:
       - ascent-config
       - ascent-discovery
@@ -61,25 +75,37 @@ services:
       - SPRING_PROFILES_ACTIVE=aws-prod
       - VAULT_ADDR=${VAULT_ADDR}
       - VAULT_TOKEN=${VAULT_TOKEN}
+    logging:
+      driver: fluentd
+      options:
+        fluentd-async-connect: "true"
+        fluentd-max-retries: "10"
+        fluentd-retry-wait: "30s"
     depends_on:
       - ascent-config
       - ascent-discovery
     networks:
         - ascentnet
   ascent-zipkin:
-      image: ascent/ascent-zipkin
-      ports:
-       - "8700:8700"
-      environment:
-        - SPRING_PROFILES_ACTIVE=aws-prod
-        - VAULT_ADDR=${VAULT_ADDR}
-        - VAULT_TOKEN=${VAULT_TOKEN}      
-      depends_on: 
-        - ascent-discovery
-        - ascent-config
-      networks: 
-        - ascentnet
-        - logging 
+    image: ascent/ascent-zipkin
+    ports:
+      - "8700:8700"
+    environment:
+      - SPRING_PROFILES_ACTIVE=aws-prod
+      - VAULT_ADDR=${VAULT_ADDR}
+      - VAULT_TOKEN=${VAULT_TOKEN} 
+    logging:
+      driver: fluentd
+      options:
+        fluentd-async-connect: "true"
+        fluentd-max-retries: "10"
+        fluentd-retry-wait: "30s"     
+    depends_on: 
+      - ascent-discovery
+      - ascent-config
+    networks: 
+      - ascentnet
+      - logging 
 networks:
   ascentnet:
     driver: overlay

--- a/ascent-platform-docker-build/fluentd/Dockerfile
+++ b/ascent-platform-docker-build/fluentd/Dockerfile
@@ -1,0 +1,9 @@
+FROM fluent/fluentd:v0.12-debian
+
+LABEL gov.va.ascent.component="logging"
+
+#Install ElasticSearch plugin
+RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-rdoc", "--no-ri", "--version", "1.9.2"]
+
+#Add our custom configurations
+ADD conf /fluentd/etc

--- a/ascent-platform-docker-build/fluentd/README.md
+++ b/ascent-platform-docker-build/fluentd/README.md
@@ -1,0 +1,6 @@
+# Fluentd Container
+Customization of the Fluentd docker container to accept log entries from Docker and forward those to ElasticSearch for storage.
+
+## Documentation
+* [Fluentd](https://docs.fluentd.org/v0.12/articles/quickstart)
+* [Fluentd ElasticSearch Plugin](https://github.com/uken/fluent-plugin-elasticsearch#installation)

--- a/ascent-platform-docker-build/fluentd/conf/fluent.conf
+++ b/ascent-platform-docker-build/fluentd/conf/fluent.conf
@@ -4,16 +4,26 @@
   port 24224
   bind 0.0.0.0
 </source>
+
+<filter *.**>
+  @type parser
+  format json
+  key_name log
+  ignore_key_not_exist true
+</filter>
+
+
+
 <match *.**>
   @type copy
   <store>
-    @type elasticsearch
+    @type elasticsearch_dynamic
     host elasticsearch
     port 9200
     user elastic
     password changeme
     logstash_format true
-    logstash_prefix fluentd
+    logstash_prefix ${record["logType"] || 'fluentd'}
     logstash_dateformat %Y%m%d
     include_tag_key true
     type_name logstash

--- a/ascent-platform-docker-build/fluentd/conf/fluent.conf
+++ b/ascent-platform-docker-build/fluentd/conf/fluent.conf
@@ -1,0 +1,33 @@
+# fluentd/conf/fluent.conf
+<source>
+  @type forward
+  port 24224
+  bind 0.0.0.0
+</source>
+<match *.**>
+  @type copy
+  <store>
+    @type elasticsearch
+    host elasticsearch
+    port 9200
+    user elastic
+    password changeme
+    logstash_format true
+    logstash_prefix fluentd
+    logstash_dateformat %Y%m%d
+    include_tag_key true
+    type_name logstash
+    tag_key @log_name
+    
+    #Buffer Settings
+    buffer_type memory
+    buffer_chunk_limit 50m
+    buffer_queue_limit 10
+    retry_wait 10s
+    flush_interval 1s
+    reconnect_on_error true
+  </store>
+  <store>
+    @type stdout
+  </store>
+</match>

--- a/ascent-platform-docker-build/logstash/Dockerfile
+++ b/ascent-platform-docker-build/logstash/Dockerfile
@@ -5,14 +5,14 @@ LABEL gov.va.ascent.component="logging"
 USER root
 WORKDIR /tmp
 # Install consul-template to populate secret data into files on disk
-RUN curl -L -o consul-template_0.19.0_linux_amd64.tgz https://releases.hashicorp.com/consul-template/0.19.0/consul-template_0.19.0_linux_amd64.tgz; \
+RUN curl -sL -o consul-template_0.19.0_linux_amd64.tgz https://releases.hashicorp.com/consul-template/0.19.0/consul-template_0.19.0_linux_amd64.tgz; \
     tar -xzf consul-template_0.19.0_linux_amd64.tgz; \
     mv consul-template /usr/local/bin/consul-template; \
     chmod +x /usr/local/bin/consul-template; \
     rm -f consul-template_0.19.0_linux_amd64.tgz
 
 # Install envconsul for retreiving secrets into ENV variables available only to the executed process
-RUN curl -L -o envconsul_0.7.1_linux_amd64.tgz https://releases.hashicorp.com/envconsul/0.7.1/envconsul_0.7.1_linux_amd64.tgz; \
+RUN curl -sL -o envconsul_0.7.1_linux_amd64.tgz https://releases.hashicorp.com/envconsul/0.7.1/envconsul_0.7.1_linux_amd64.tgz; \
     tar -xzf envconsul_0.7.1_linux_amd64.tgz; \
     mv envconsul /usr/local/bin/envconsul; \
     chmod +x /usr/local/bin/envconsul; \
@@ -29,12 +29,15 @@ WORKDIR /usr/share/logstash
 
 COPY logstash.conf pipeline/logstash.conf
 COPY logstash.yml config/logstash.yml
+COPY template/gelf.conf pipeline/gelf.conf
 
 # Add our runwrapper
 COPY run-wrapper.sh run-wrapper.sh
 
 #Expose the Filebeat input port
 EXPOSE 5044
+#Expose the GELF input port
+EXPOSE 12201
 
 # Add our envconsul config, consul-template configuration, and templates
 COPY template/ template/

--- a/ascent-platform-docker-build/logstash/template/gelf.conf
+++ b/ascent-platform-docker-build/logstash/template/gelf.conf
@@ -1,0 +1,6 @@
+input {
+  gelf {
+    id => "ascent"
+    port => 12201
+  }
+}


### PR DESCRIPTION
Replace Filebeat and Logstash with FluentD. FluenD containers are deployed on each docker node and the docker fluentd logging driver is used to aggregate the logs without needing to access the docker logs directly.