### PR TITLE
Es config

### DIFF
--- a/ascent-platform-docker-build/es-config/Dockerfile
+++ b/ascent-platform-docker-build/es-config/Dockerfile
@@ -7,6 +7,8 @@ USER root
 ENV KIBANA_PASSWORD changeme
 ENV ES_PASSWORD changeme
 ENV REPLICA_AMOUNT 3
+ENV ZIPKIN_STORAGE_ELASTIC_SEARCH_USERNAME zipkin
+ENV ZIPKIN_STORAGE_ELASTIC_SEARCH_PASSWORD changeme
 
 WORKDIR /tmp
 # Install consul-template to populate secret data into files on disk

--- a/ascent-platform-docker-build/es-config/changepass.sh
+++ b/ascent-platform-docker-build/es-config/changepass.sh
@@ -8,9 +8,56 @@ generate_pass_data() {
 EOF
 }
 
+generate_zipkin_role_data() {
+  cat <<EOF
+{
+  "cluster": [],
+  "indices": [
+    {
+      "names": [ "zipkin*" ],
+      "privileges": ["all"]
+    }
+  ]
+}
+EOF
+}
+
+generate_developer_role_data() {
+  cat <<EOF
+{
+  "cluster": [],
+  "indices": [
+    {
+      "names": [ "applogs-*", "auditlogs-*", ".kibana" ],
+      "privileges": ["view_index_metadata", "read", "monitor"]
+    }
+  ]
+}
+EOF
+}
+
+generate_user_data() {
+  cat <<EOF
+{
+  "password" : "$1",
+  "roles" : [ "zipkin" ]
+}
+EOF
+}
+
 echo "---- changing password"
 default_pass=changeme
-curl -XPOST -s -u elastic:$default_pass 'elasticsearch:9200/_xpack/security/user/elastic/_password?pretty' -H 'Content-Type: application/json' -d "$(generate_pass_data $ES_PASSWORD)"
+curl -XPOST -sk -u elastic:$default_pass 'elasticsearch:9200/_xpack/security/user/elastic/_password?pretty' -H 'Content-Type: application/json' -d "$(generate_pass_data $ES_PASSWORD)"
 echo "---- changing kibana user pass"
-curl -XPOST -s -u elastic:$ES_PASSWORD 'elasticsearch:9200/_xpack/security/user/kibana/_password?pretty' -H 'Content-Type: application/json' -d "$(generate_pass_data $KIBANA_PASSWORD)"
+curl -XPOST -sk -u elastic:$ES_PASSWORD 'elasticsearch:9200/_xpack/security/user/kibana/_password?pretty' -H 'Content-Type: application/json' -d "$(generate_pass_data $KIBANA_PASSWORD)"
+
+# Create role for Zipkin application
+curl -XPOST -sk -u elastic:$ES_PASSWORD 'elasticsearch:9200/_xpack/security/role/zipkin' -H 'Content-Type: application/json' -d "$(generate_zipkin_role_data)"
+
+# Create developer role for read-only access to application logs
+curl -XPOST -sk -u elastic:$ES_PASSWORD 'elasticsearch:9200/_xpack/security/role/developer' -H 'Content-Type: application/json' -d "$(generate_developer_role_data)"
+
+# ZIPKIN_STORAGE_ELASTIC_SEARCH_* environment variables are populated by envconsul from secrets in Vault
+echo "---- Create Zipkin user account"
+curl -XPOST -sk -u elastic:$ES_PASSWORD "elasticsearch:9200/_xpack/security/user/$ZIPKIN_STORAGE_ELASTIC_SEARCH_USERNAME" -H 'Content-Type: application/json' -d "$(generate_user_data $ZIPKIN_STORAGE_ELASTIC_SEARCH_PASSWORD)"
 

--- a/ascent-platform-docker-build/es-config/template/envconsul-config.hcl
+++ b/ascent-platform-docker-build/es-config/template/envconsul-config.hcl
@@ -31,12 +31,18 @@ secret {
     path = "secret/elasticsearch/admin"   
 }
 
-
 # Kibana User Secrets
 secret {
     format = "kibana_{{ key }}"
     no_prefix = true
     path = "secret/elasticsearch/kibana"
+}
+
+# Zipkin User Secrets
+secret {
+    format = "{{ key }}"
+    no_prefix = true
+    path = "secret/application"
 }
 
 

--- a/ascent-platform-docker-build/fluentd/Dockerfile
+++ b/ascent-platform-docker-build/fluentd/Dockerfile
@@ -2,7 +2,7 @@ FROM fluent/fluentd:v0.12-debian
 
 LABEL gov.va.ascent.component="logging"
 
-ENV ES_PASSWORD=elasticsearch
+ENV ES_PASSWORD=changme
 
 
 #Install ElasticSearch plugin

--- a/ascent-platform-docker-build/fluentd/Dockerfile
+++ b/ascent-platform-docker-build/fluentd/Dockerfile
@@ -2,7 +2,7 @@ FROM fluent/fluentd:v0.12-debian
 
 LABEL gov.va.ascent.component="logging"
 
-ENV ES_PASSWORD=changme
+ENV ES_PASSWORD=changeme
 
 
 #Install ElasticSearch plugin

--- a/ascent-platform-docker-build/fluentd/conf/fluent.conf
+++ b/ascent-platform-docker-build/fluentd/conf/fluent.conf
@@ -9,7 +9,9 @@
   @type parser
   format json
   key_name log
+  reserve_data true
   ignore_key_not_exist true
+  suppress_parse_error_log true
 </filter>
 
 


### PR DESCRIPTION
Create user account and role in ElasticSearch for the Zipkin application.
Create a read-only role for developers in ElasticSearch. Individual user accounts still need to be created by hand.