### PR TITLE
Logstack bugfix

### DIFF
--- a/ascent-platform-docker-build/docker-compose.logging.override.yml
+++ b/ascent-platform-docker-build/docker-compose.logging.override.yml
@@ -9,7 +9,7 @@ services:
             - "ES_JAVA_OPTS=$ES_JAVA_OPTS"
             - VAULT_TOKEN=vaultroot
             - VAULT_ADDR=http://vault:8200
-            - SECURE_CONNECT=true
+            - SECURE_CONNECT=false
         ports:
             - 9200:9200
     es-config:
@@ -18,19 +18,19 @@ services:
         environment:  
             - VAULT_TOKEN=vaultroot
             - VAULT_ADDR=http://vault:8200
-            - SECURE_CONNECT=true
+            - SECURE_CONNECT=false
     kibana:
         build:
             context: ./kibana   
         environment:  
             - VAULT_TOKEN=vaultroot
             - VAULT_ADDR=http://vault:8200
-            - SECURE_CONNECT=true
+            - SECURE_CONNECT=false
     fluentd:
         build:
             context: ./fluentd
         environment:  
-            - SECURE_CONNECT=true
+            - SECURE_CONNECT=false
             - VAULT_TOKEN=vaultroot
             - VAULT_ADDR=http://vault:8200
 networks:

--- a/ascent-platform-docker-build/docker-compose.logging.yml
+++ b/ascent-platform-docker-build/docker-compose.logging.yml
@@ -8,6 +8,7 @@ services:
             - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
             - REPLICA_AMOUNT=1
             - MIN_MASTER_NODES=1 
+            - SECURE_CONNECT=true
         networks: 
             logging:
                 aliases:
@@ -39,6 +40,7 @@ services:
         container_name: es-config
         environment:
             - REPLICA_AMOUNT=1
+            - SECURE_CONNECT=true
         networks:
             - logging
         depends_on:
@@ -52,6 +54,8 @@ services:
     fluentd:
         image: ascent/fluentd
         container_name: fluentd
+        environment:
+            - SECURE_CONNECT=true
         ports:
             - 24224:24224
         networks:
@@ -65,6 +69,8 @@ services:
 
     kibana:
         image: ascent/ascent-kibana
+        environment:
+            - SECURE_CONNECT=true
         ports: 
             - 5601:5601
         networks: 

--- a/ascent-platform-docker-build/elasticsearch/run-wrapper.sh
+++ b/ascent-platform-docker-build/elasticsearch/run-wrapper.sh
@@ -15,10 +15,10 @@ if [[ -z $VAULT_ADDR ]]; then
 fi
 
 echo "--- polling to wait for vault"
-    until $(curl -XGET --insecure --fail --output /dev/null --silent -H "X-Vault-Token: $VAULT_TOKEN" $VAULT_ADDR/v1/sys/health); do
-       echo "--trying again"
-       sleep 5
-    done
+until $(curl -XGET --insecure --fail --output /dev/null --silent -H "X-Vault-Token: $VAULT_TOKEN" $VAULT_ADDR/v1/sys/health); do
+    echo "--trying again"
+    sleep 5
+done
 
 if [[ -z $SECURE_CONNECT ]]; then
     SECURE_CONNECT=false

--- a/ascent-platform-docker-build/elasticsearch/run-wrapper.sh
+++ b/ascent-platform-docker-build/elasticsearch/run-wrapper.sh
@@ -15,17 +15,10 @@ if [[ -z $VAULT_ADDR ]]; then
 fi
 
 echo "--- polling to wait for vault"
-<<<<<<< HEAD
 until $(curl -XGET --insecure --fail --output /dev/null --silent -H "X-Vault-Token: $VAULT_TOKEN" $VAULT_ADDR/v1/sys/health); do
     echo "--trying again"
     sleep 5
 done
-=======
-    until $(curl -XHEAD --insecure --fail --output /dev/null --silent -H "X-Vault-Token: $VAULT_TOKEN" $VAULT_ADDR/v1/sys/health?standbyok=true); do
-       echo "--trying again"
-       sleep 5
-    done
->>>>>>> 2cde44c2fe82f8c0ca300ab499b976a55afe60d3
 
 if [[ -z $SECURE_CONNECT ]]; then
     SECURE_CONNECT=false

--- a/ascent-platform-docker-build/elasticsearch/run-wrapper.sh
+++ b/ascent-platform-docker-build/elasticsearch/run-wrapper.sh
@@ -15,7 +15,7 @@ if [[ -z $VAULT_ADDR ]]; then
 fi
 
 echo "--- polling to wait for vault"
-    until $(curl -XGET --insecure --fail --output /dev/null --silent -H "X-Vault-Token: $VAULT_TOKEN" $VAULT_ADDR/v1/secret/application); do
+    until $(curl -XGET --insecure --fail --output /dev/null --silent -H "X-Vault-Token: $VAULT_TOKEN" $VAULT_ADDR/v1/sys/health); do
        echo "--trying again"
        sleep 5
     done

--- a/ascent-platform-docker-build/es-config/changepass.sh
+++ b/ascent-platform-docker-build/es-config/changepass.sh
@@ -8,10 +8,13 @@ generate_pass_data() {
 EOF
 }
 
+# "cluster" privilege as "manage". Required for zipkin user, else get connect exception
+# Builds on monitor and adds cluster operations that change values in the cluster. 
+# This includes snapshotting, updating settings, and rerouting.
 generate_zipkin_role_data() {
   cat <<EOF
 {
-  "cluster": [],
+  "cluster": [ "manage"],
   "indices": [
     {
       "names": [ "zipkin*" ],

--- a/ascent-platform-docker-build/es-config/set-url.sh
+++ b/ascent-platform-docker-build/es-config/set-url.sh
@@ -8,5 +8,7 @@ fi
 if [ "$SECURE_CONNECT" = true ]; then
     consul-template -once -config="$CONSUL_TEMPLATE_CONFIG" -vault-addr="$VAULT_ADDR" -vault-token="$VAULT_TOKEN"
     echo "--cacert /usr/share/elasticsearch/config/ca.pem  https://elastic.internal.vets-api.gov:9200" >> es-url
+else
+    echo "elastic.internal.vets-api.gov:9200" >> es-url
 fi
 

--- a/ascent-platform-docker-build/redis-sentinel/redis-sentinel-entrypoint.sh
+++ b/ascent-platform-docker-build/redis-sentinel/redis-sentinel-entrypoint.sh
@@ -6,7 +6,7 @@ CMD=$START_COMMAND
 if [[ $VAULT_TOKEN ]]; then
     echo "using vault token"
     echo "--- polling to wait for vault"
-    until $(curl -XGET --insecure --fail --output /dev/null --silent -H "X-Vault-Token: $VAULT_TOKEN" $VAULT_ADDR/v1/secret/application); do
+    until $(curl -XGET --insecure --fail --output /dev/null --silent -H "X-Vault-Token: $VAULT_TOKEN" $VAULT_ADDR/v1/sys/health); do
        echo "--trying again"
        sleep 5
     done

--- a/ascent-platform-docker-build/start-all-build.sh
+++ b/ascent-platform-docker-build/start-all-build.sh
@@ -8,4 +8,5 @@ docker-compose -f docker-compose.vault.yml \
 	-f docker-compose.logging.override.yml \
 	-f docker-compose.cache.yml \
 	-f docker-compose.cache.override.yml \
+	-f docker-compose.queue.override.yml \
 	up --build -d

--- a/ascent-platform-docker-build/start-all.sh
+++ b/ascent-platform-docker-build/start-all.sh
@@ -8,6 +8,7 @@ docker-compose -f docker-compose.vault.yml \
 	-f docker-compose.logging.override.yml \
 	-f docker-compose.cache.yml \
 	-f docker-compose.cache.override.yml \
+	-f docker-compose.queue.override.yml \
 	pull
 
 docker-compose -f docker-compose.vault.yml \
@@ -18,4 +19,5 @@ docker-compose -f docker-compose.vault.yml \
 	-f docker-compose.logging.override.yml \
 	-f docker-compose.cache.yml \
 	-f docker-compose.cache.override.yml \
+	-f docker-compose.queue.override.yml \
 	up -d

--- a/ascent-platform-docker-build/stop-all.sh
+++ b/ascent-platform-docker-build/stop-all.sh
@@ -7,4 +7,5 @@ docker-compose -f docker-compose.yml \
 	-f docker-compose.cache.yml \
 	-f docker-compose.vault.yml \
 	-f docker-compose.vault.override.yml \
+	-f docker-compose.queue.override.yml \
 	down -v


### PR DESCRIPTION
- correct setting the elasticsearch url when the SECURE_CONNECT environment variable is set to false.

- set SECURE_CONNECT explicitly to false for docker-compose.logging.override.yml so local testing won't have encrypted connections in stack

- set SECURE_CONNECT explicitly to true in docker-composelogging.yml so that there can be encrypted connections in non local environments