### PR TITLE
Updates to remove original key-value pair. Added @ERROR label

### DIFF
--- a/ascent-platform-docker-build/fluentd/conf/fluent.conf
+++ b/ascent-platform-docker-build/fluentd/conf/fluent.conf
@@ -9,12 +9,10 @@
   @type parser
   format json
   key_name log
-  reserve_data true
+  # default is false added explicitly
+  reserve_data false
   ignore_key_not_exist true
-  suppress_parse_error_log true
 </filter>
-
-
 
 <match *.**>
   @type copy
@@ -32,7 +30,7 @@
     logstash_prefix ${record["logType"] || 'fluentd'}
     logstash_dateformat %Y%m%d
     include_tag_key true
-    type_name logstash
+    type_name fluentd
     tag_key @log_name
     
     #Buffer Settings
@@ -47,3 +45,37 @@
     @type stdout
   </store>
 </match>
+
+<label @ERROR>
+    <match *.**>
+      @type copy
+      <store>
+        @type elasticsearch_dynamic
+        host elastic.internal.vets-api.gov
+        port 9200
+        user elastic
+        #changed to https when SECURE_CONNECT is set to true
+        scheme http
+        password "#{ENV['ES_PASSWORD']}"
+        #ssl_verify is set to true when SECURE_CONNECT is set to true
+        ssl_verify false
+        logstash_format true
+        logstash_prefix ${record["logType"] || 'fluentd'}
+        logstash_dateformat %Y%m%d
+        include_tag_key true
+        type_name fluentd
+        tag_key @log_name
+        
+        #Buffer Settings
+        buffer_type memory
+        buffer_chunk_limit 50m
+        buffer_queue_limit 10
+        retry_wait 10s
+        flush_interval 1s
+        reconnect_on_error true
+      </store>
+      <store>
+        @type stdout
+      </store>
+    </match>
+</label>

--- a/ascent-platform-docker-build/fluentd/conf/fluent.conf
+++ b/ascent-platform-docker-build/fluentd/conf/fluent.conf
@@ -74,8 +74,5 @@
         flush_interval 1s
         reconnect_on_error true
       </store>
-      <store>
-        @type stdout
-      </store>
     </match>
 </label>


### PR DESCRIPTION
@jasonluck : This isn't the best configuration as it duplicates ES store information. However, I am trying to achieve following:
1) Remove original key-value pair in "log" field as it's duplicate and would save lot of disk space
2) Added @ERROR label to capture unexpected format logs in fluentd* index

I am not sure how to avoid duplicating <store> section information in fluent.conf. Please review it and let me know your thoughts.